### PR TITLE
HaloDB.size and HaloDB.contains method

### DIFF
--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -56,6 +56,10 @@ public final class HaloDB {
         }
     }
 
+    public boolean contains(byte[] key) {
+        return dbInternal.contains(key);
+    }
+
     public void close() throws HaloDBException {
         try {
             dbInternal.close();

--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -40,6 +40,10 @@ public final class HaloDB {
         }
     }
 
+    public int size(byte[] key) {
+        return dbInternal.size(key);
+    }
+
     public boolean put(byte[] key, byte[] value) throws HaloDBException {
         try {
             return dbInternal.put(key, value);

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -381,11 +381,15 @@ class HaloDBInternal {
                 return false;
             }
 
-            return  true;
+            return true;
         } else {
             logger.info("snapshot not existed");
             return true;
         }
+    }
+
+    boolean contains(byte[] key) {
+        return inMemoryIndex.containsKey(key);
     }
 
     void delete(byte[] key) throws IOException {

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -414,6 +414,15 @@ class HaloDBInternal {
         return inMemoryIndex.size();
     }
 
+    int size(byte[] key) {
+        InMemoryIndexMetaData metaData = inMemoryIndex.get(key);
+        if (metaData == null) {
+            return -1;
+        }
+
+        return metaData.getValueSize();
+    }
+
     void setIOErrorFlag() throws IOException {
         DBMetaData metaData = new DBMetaData(dbDirectory);
         metaData.loadFromFileIfExists();

--- a/src/test/java/com/oath/halodb/HaloDBTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBTest.java
@@ -77,6 +77,33 @@ public class HaloDBTest extends TestBase {
     }
 
     @Test(dataProvider = "Options")
+    public void testPutAndContainsDB(HaloDBOptions options) throws HaloDBException {
+        String directory = TestUtils.getTestDirectory("HaloDBTest", "testPutAndGetDB");
+
+        options.setCompactionDisabled(true);
+
+        HaloDB db = getTestDB(directory, options);
+
+        int noOfRecords = 10_000;
+        List<Record> records = TestUtils.insertRandomRecordsOfSize(db, noOfRecords, 128);
+
+        List<byte[]> missingKeys = new ArrayList<>();
+        for (int i = 0; i < noOfRecords; i++) {
+            missingKeys.add(TestUtils.generateRandomByteArray(64));
+        }
+
+        List<Record> actual = new ArrayList<>();
+        db.newIterator().forEachRemaining(actual::add);
+
+        Assert.assertTrue(actual.containsAll(records) && records.containsAll(actual));
+
+        records.forEach(record -> Assert.assertTrue(db.contains(record.getKey())));
+
+        missingKeys.forEach(key -> Assert.assertFalse(db.contains(key)));
+    }
+
+
+    @Test(dataProvider = "Options")
     public void testCreateCloseAndOpenDB(HaloDBOptions options) throws HaloDBException {
 
         String directory = TestUtils.getTestDirectory("HaloDBTest", "testCreateCloseAndOpenDB");


### PR DESCRIPTION
Adding two features:

- check value size associated with a given key without reading entire value from the disk. The size is stored in the memory index.
- test if a key is stored in the database.