### PR TITLE
update images links to those hosted on github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ HaloDB is a fast and simple embedded key-value store written in Java. HaloDB is 
 HaloDB was written for a high-throughput, low latency distributed key-value database that powers multiple ad platforms at Yahoo, therefore all its design choices and optimizations were
 primarily for this use case.  
 
-Basic design principles employed in HaloDB are not new. Refer to this [document](https://github.com/yahoo/HaloDB/blob/master/docs/WhyHaloDB.md) for more details about the motivation for HaloDB and its inspirations.  
+Basic design principles employed in HaloDB are not new. Refer to this [document](docs/WhyHaloDB.md) for more details about the motivation for HaloDB and its inspirations.  
  
 HaloDB comprises of two main components: an index in memory which stores all the keys, and append-only log files on
 the persistent layer which stores all the data. To reduce Java garbage collection pressure the index 
 is allocated in native memory, outside the Java heap. 
 
-![HaloDB](https://lh3.googleusercontent.com/JxnA8Kznn2jZrG1ytAEo5OZ5OCrnfhDOaLfK1D30SZSz_Dl1IU2666fDc8lGGBW1zGSEjOBWw07C5eltiSmOvxc34OhO0nzqaSxGzE-AeVS8gihFp4E8NBFOnzmjkfsPsQO69x5x2Q=w1576-h872-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/halodb.png)
 
 ### Basic Operations. 
 ```java
@@ -211,7 +211,7 @@ Therefore, don't interrupt threads while they are doing IO operations.
 * HaloDB don't support range scans or ordered access.
 
 # Benchmarks.
-[Benchmarks](https://github.com/yahoo/HaloDB/blob/master/docs/benchmarks.md).
+[Benchmarks](docs/benchmarks.md).
   
 # Contributing
 Contributions are most welcome. Please refer to the [CONTRIBUTING](https://github.com/yahoo/HaloDB/blob/master/CONTRIBUTING.md) guide 

--- a/docs/WhyHaloDB.md
+++ b/docs/WhyHaloDB.md
@@ -51,17 +51,17 @@ Therefore it was decided to write a new storage engine from scratch; thus the Ha
 ## Performance test results on our production workload. 
 The following chart shows the results of performance tests that we ran with production data against a performance test box with the same hardware as production boxes. The read requests were kept at 50,000 QPS while the write QPS was increased.
 
-![SSD](https://lh3.googleusercontent.com/VKaFiNoM2zzyJ6TrGO6IHBcmT4pNUouGlhtYPQLwNfSyV2jvK1oBEvYevGaJ-AGYVHoM0M2VmOUx9U3KNmFXNyVbg6bHqwR-iAhAavtY6rF1JYFskCv4Vc8mLlGaS_LB2PthhpGwzRhB0FBGziIq5bvfTY-yuLKYbTgT8taWyeq1Dda6BvjSQ-jj1-d2IGixi6zADNOJ9XoVMQZxO6hGTECdzHgvZi7rqy95f2kGx1C4MIT6TwvEzavJztEBDZGS_fLNwnIHPVz5aNrzkC5GVSt80IelR4wllginxPsp0ja30dAc1bPFq4pjSHj-gWiXhqpAqTCTPmosqly8yuTQyV2QnXSI-X8TYSwgazsvgeMKmxnav7mTSA2mf1ljU1D34h0e_xiIRiQcTvEvhc_dvf9LKJWBfVEQdE4tfvfOHcfGotk868BO4zmsYcOOsWyQl4eg9gTMjdBBmcmnh8qwBIKGX3j0uc8zc6RITGcdFRFzh59sR3Gop0-cNk5HvKJlyzWSO0DQgDVzUeLrBj1FvV4zclAn3hoLmO8n51fKDy3lrctvhSxIH-wxSdy4hZWEQYGc8KdDHGpN4KCTwinEiqh5rsOIBhBc1JC9DFMgD7CI_gA1gvweVp25grC5AmxkuMMxG2nqZ2Kr99WLecC1QsDN0FP2CGmB=w1970-h1106-no) 
+![SSD](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/ssd.png) 
 As you can see at the 99th percentile HaloDB read latency is an order of magnitude better than that of Kyoto Cabinet. 
 We recently upgraded our SSDs to PCIe NVMe SSDs. This has given us a significant performance boost and has narrowed the gap between HaloDB and Kyoto Cabinet, 
 but the difference is still significant:
 
-![PCIe NVMe SSD](https://lh3.googleusercontent.com/S7q5hJtfhso5oT1_4fm8IJeFBxi6FDIZHhDQZw3664BAOz-DIkIoRdvE8pTCfjmtNGV61iU1YPtUctBMSvjFJuvmLUU7jCVVXaijCZlEWX7PZguQ-AIbou3NvRlkWcJjRvCi2bIei4mIchReUlBaB9WG8VChzifMfjNbYx6n7KwOBX64lDZM3XG5ACNIvuORLhgs4NVLdjbJd30_rA-luKapvjX0VSw8xTMxtY0i9HXDcdyDN0Wk6ikzUJI54r29tMoyeiG6bzblOGPJXbH_jmp28oplvxRs6FwexK2dy0cQlasOI87esweNF0H4cqLEWWYbgipooxhBqY9ZIpxSiEmwBIpUpOCYfNe41waF94ZngzdIUtiAgE40oTViDcjA1wUtwfLmRVDNYU9j3OWnRdbfYJ5Ha1bYbZx9pil9ntMzCZuj1dEmI5I1_DwINIYjSNBDMorZ-LynFwmkEOoUPqpGxMdSB2CexH5p7CRAXfd6pA3m2hY-cmg8NAQHKfW_krKSYyfTlN0cLBA9-CaWappMnqMSAiD176MMQnNy1QxIrsLQ_fkMYCcS-pi39XILZTISZccWvZa84u2suZ7ampZQ8tFD2vTPGLgonlpryo5RXci1iXQRXxuToWW8c9jxCkbjOorilHZqh84C3vX9DkXN9qBTYNM5=w1970-h1100-no)
+![PCIe NVMe SSD](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/pcie-ssd.png)
  
 Of course, these are results from performance tests, but nothing beats real data from hosts running in production.
 Following chart shows the 99th percentile latency from a production server before and after migration to HaloDB.
 
-![99th percentile in ms](https://lh3.googleusercontent.com/lg4VILxDcNwi2XOUCbJrFtKgTN7z08tLC6SpFyEyXqs4CDropEBAljQa5mf4LLG5fSOaXXKJs5HwEl15ID3x8JgVK7Acdz-tCyNVQouSdeOw6KAFZDN8L4_--ojDr3IxkI9rho7NEPuvm-yt80ZHF33jxKV5TlxsW7xXDxIe7OoOi9QkpwfID_QMTlJwfRBxOHf3G2PeHYRjc23UqO8Y1zDuDvRcqCF09oNM2w_K-3dpr6P5ihdOF5k054Nr4WXaNfdiMmjzKtvR8k5YGGTNSOunzVwc0YzI4TKKV3URTTjkEjhZzdl4DfHwjD8t507nPHpKh6OpUmlXcaUJkp7RHx5pGDTGTN86PMQxfNMizOm89NXc8ULivzCTZOdIMdX5BXtS0oza2N5ZgW9xRNcrj6GjY81AiiMfiHYVqAnRPXzhWTciwnzQ8AtZGihTjbnR6zKkrOQ00H1O-ZoeDcnWBPsP5KjAmXTyE3zXMXMRhZdc26yX9JGFctM7755h2NfK9rqXqz60sd6-0uaDTujipl7pLw_l7kAXTYiBHNwQsmE07HTVLWk-L_uA9Cnk_S017YWz64zP3bcnzOhuLAIOaTCzslBboPHX0g0WxR7MeLUgpj4mXpn6TUMKu95CmUFOa91HVwX-X3E1g2PXsESLznoZG_wE62kJ=w2092-h852-no) 
+![99th percentile in ms](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/before-after.png) 
  
 HaloDB has thus given our production boxes a 50% improvement in capacity while consistently maintaining a sub-millisecond latency at the 99th percentile.
  

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -14,11 +14,11 @@
   Key size was 8 bytes and value size 1024 bytes. Tests created a db with 500 million records with total size of approximately 
   500GB. Since this is significantly bigger than the available memory it will ensure that the workload will be IO bound, which is what HaloDB was primarily designed for.
   
-  Benchmark tool can be found [here](https://github.com/yahoo/HaloDB/tree/master/benchmarks)  
+  Benchmark tool can be found [here](../benchmarks)  
   
 ## Test 1: Fill Sequential.
 Create a new db by inserting 500 million records in sorted key order.
-![HaloDB](https://lh3.googleusercontent.com/P72df6yc2SONW3eogrRNZ3F4y39KyPdoHztDRvMroS5kXUDMTIH58aGb9Gysjx6GF3RJY-EbOMGE5hgJ06WvNuGLmSaHArpe24x8OiOnnsAsNRKRTN7m2JZJCZfD_jzEj8VHMZcyIxYDdOVSA95wB9YC3kxiDQTd0FiFOuu570IxaXZYwUAPtFlDlBURSJ_olbGl-hxjw0EY-OyM2yPhLXKZuJ_vsw4SJ6JFqAshUE9fgN4gcgKkHHYUgSVY6MBe8pM1sUJ96dW4uQ0EXH4n3D-cRciUEZAb2Uv6RJECZlCaDi66-Leix9UESopgOVYHhj9sb2fCjqy9puf2e3tufTwPavw7Rl4kQ1m_Q9apwkUnrciq3lzT3o-ajeGP3jzyw9v3PK1VA1rX29f-3PBwFIipP2ZY8JYnz0ETKGqVr6xchKd-AekSw0zxNsMu_LZRNyA5J3YPbCQr8yP4eoJH1HX_SY7sli4_dqCaXbvaFCOywORQTbF6YYtCQeq1MGwv2FShwJIXp-UMEg-2GrmAWm9EVsHXNZ6XXeUKh5aK_CTspMQeAw3w32Vo4py1pVDRWWevTCR30DEw70Mju9-IkkAxi_n_bT8paBo9mISkixxncXUPOd_lDTe_txC9uPJGtAU_Axl9Jyh-zMPpb6zJdZJw-fuf0kWw=w1790-h966-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/fill-sequential.png)
 
 DB size at the end of the test run. 
 
@@ -31,11 +31,11 @@ DB size at the end of the test run.
 
 ## Test 2: Random Read
 Measure random read performance with 32 threads doing _640 million reads_ in total. Read ahead was disabled for this test.    
-![HaloDB](https://lh3.googleusercontent.com/yCIQefIM3cLZ16ZcCQrood-xycLt_rISqmLroMwDnDNIpHj2pYQnOlEwg4DjpuOiTqaSz-le_sJmZGqvGGk-RjIyxkqXbfL0HbzEGWPrqDVCjw_jLj3bGbx2g_VvIy6H2YF2wL6GL1Z1YK5c5Flmuq6Br1yOi_pLDcfpF956vMQEveI5kti4l3ek7l8jLLjln4nXorIgaGIrJXZwxDFebn32TW1nDeGWz4uDjHVDScDMCIme_GUrTwVgjeF6H7IFW82YXn7ecVVd_5FTFesHbubBB48aqOCFkjQQOgwS05zHZsF4hO06fvbiDs2fex8tGddMYSO38VdKp-Rc6882KjZAhqcW20v8OLZOLBg07bc_9VcsKVhWqbvEVDOGzdHgIto7KG2KHHlKV0-XqJakjmVLwdQKOFE2RGf41czMSVWsCvIygOnkCBcoU34K1L2TPxcjhlk-EWyY9dnnFuBtc8UZl5yg3N-3t49Zd9mDfoLCgIazizKmOqxxxd3obcUAeSpMV2ibkaQKO0kAnX7VNSqR1OrsAzS1n8zWF2CGSurmYkaUJ3_WNPCdzyG2IaLFnC7cNhVR5j8wd_ziPRuDSv11-kx67r7o_6HEJY2QVzBbh5WbO53t0ufu1JGB8VoWcgtDKRiwqyCTxwKe18QawfcWJ8bs_Lyo=w1952-h1076-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/random-reads.png)
    
 ## Test 3: Random Update.
 Perform 500 million updates to randomly selected records.    
-![HaloDB](https://lh3.googleusercontent.com/E4eGjSN-c-lKZ_13kInENupW5MLTUs4ZnMl5y8ZA7gXm7GI-oTC0pLXJZJH_u9Ip1FxpKcVNNN8NadWOrzMSQbEGVbQdlf-9kY07Qoy_ZfOBSLptA_Ym14GD3A2D0ySqH6dlkG3f3FmZv53Tlnx_jxE_ZY0uvqJcMhrS4Zk8RmKSL49RRRTsKe0WX3Ldeqkn9YGf67CHNjzQDHog6sprZdfCGWti1PjfCKytjV5JQ1iB3YLPdJJsyZIXA8oFUSV1qqfjPxXngheKlrN3Py1LN-e_Igj_HrqyTw6NpQLE9i_FLEQjeLdPkXmSHTf2OX402YgcnuqhB5AtBEDMX8OhuRxXPX6_mTySfrQrTkkfAa3JgB48Hac1uMxeyqS10YmX1g_0-brHqcK7wfeemhB4zy2SbKqka3I5piakVTTku4CUCsLeyI_8lmTIAaISVjOrUwQQpiDzTl4dtVD91oTo-hMvVfAgTiDtGUfN6f5yt4mm9F_RZ99o3IIBxWVMApZzMOso2IAMczIoHQtH7GeJmoDhhqVVBwrO4zfSAYPDeSNB0L1ZdvtIBnVtTrMQZgK9XYfQNKFALnXWusKBk6962k2Nd5JAWDHgsCsvUITxqOjnFb9-q3F4rAwcE_S_C0cmJNYgklK1bnPeGwqpJaDpEOrEWmTtcZn_=w1940-h1060-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/random-update.png)
 
 DB size at the end of the test run. 
 
@@ -47,11 +47,11 @@ DB size at the end of the test run.
 
 ## Test 4: Fill Random. 
 Insert 500 million records into an empty db in random order. 
-![HaloDB](https://lh3.googleusercontent.com/6reqAGgw1S2Q2BJP9A-HBHs6CBvkRcxpX78tDLYi1usZpI1o1EsGjDQoUgnE-H33oV8SzylwLZSaFWafXpS-s4JzyheKK1dyOoO1xcacN0xI0jYAbNfZy5A_tnpLmvhM9FpOI0xOjGgvVe3jEZn5rYP9r2dxzVuQ4aK_mkJKJLc6ktTiNFmctH2B8wwq31bM-W5NAxNx8AaMfrQdsWmcK62LU-_-r5oXTaprkAN4pHo_jjhJ3pOkmk8u8llK9yIyxJjSDxNrVrUWdY_rYgRpYWXtJqFExAv9befCOM4_JWBEVKcTA9vmZdLcy2d1w1ia0_whIH-s4dTGO6FKp1TlF9s-HFuqj-P-mHcVGwPzJx_ARnsMNri6ts4dJAxahkUEBihqGTkohxSO9UQZ5D2s-IpRvsuAu1UGFjK0nUCiBNgT3SERXdUosj0Pd4pcBKNOpKfAl6338nigKYsIZXWCOb55mxUG3-ZbqXdCMCLMefrqg8BoxR8dtF5TssbTKsBTVPiM-XzsqeEaYsHuKIT3qnKFX3cXf2N9mCtjobdc9gsv2FalXRrA1hkCZIUDmr31yqUkv6Lo8jckap_uEGfM22cSewe2pDJOelEO67FX9tX-u7YMZ8JtyHllhYBFdP8rIHQNuByKu7RvvBiF5huUKo_gq-S-wv1c=w1944-h1062-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/fill-random.png)
 
-## Test 4: Read and update. 
+## Test 5: Read and update. 
 32 threads doing a total of 640 million random reads and one thread doing random updates as fast as possible.  
-![HaloDB](https://lh3.googleusercontent.com/sJtr8EdXWyw6IjG9oUn6Vb4YAW-KDnfMcqYTDAYOLO3N3sxt-FM-4JaA8hHKQeA63yzHZ9wGvxtp9BXDu-moxJ5K-bqFY2XBXUu4J82TiQ6SFOwC5UI73BxKdg05iS7dzJfe-lQM491xi_7aHnEfkZXOyxy0c8-zz_v4LgbeWILxGKHaGLyqj18dRIKpMw1Gv8fi5kvhSDu8YfsCp6BqZCI3CYUqduKnnHjFK7WAIvyaC6pFr3PkpU4C1ATpW9SGSeATlqbWOZgzMAVu7lZYJEi7xb3HMOkrc6w5kawVnJ62QBh9DRrila5F7fsEbR_sUPbL_WTYHvxMC0NVA2TjSUffg0wo4VJ75251s75DSLuB-Y3jlZ9i9vM6SCvGoPfeizgf8TU8iIc-9Ws9v4nLqewufM8ft4vlyoIA6aqUB_NVOtN7_FXJ40irUoEDzKDUP-cVzWlFWIpP1HXasxmbzwP34S1_oiyn2pAcC3VpGZ5RuzF-vjapscRdKYiFOJE8S5ywiZZYcCvOxwS3lKpMNs4Y_qkgPen3PTDALteoLyV9EKm90EJEMNw6Pm_amM_wj0pk7qjPpTlkhcSspwPXPvnWLJR2EhldWSFq32R8fUsFuFX5dRXmy4ORpHScuCAu5KYx2dwQSCR0WLyDvX8rKPlhNha3nece=w1950-h1066-no)
+![HaloDB](https://raw.githubusercontent.com/amannaly/HaloDB-images/master/images/read-update.png)
 
 ## Why HaloDB is fast.
 HaloDB doesn't claim to be always better than RocksDB or KyotoCabinet. HaloDB was written for a specific type of workload, and therefore had


### PR DESCRIPTION
Images used in the documentation points to those hosted on google photos. Unfortunately those links have now expired. Point links to images hosted on github. 