### PR TITLE
Loading index and tombstone files in parallel to speed up db open

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,21 @@ is allocated in native memory, outside the Java heap.
             // Open a db with default options.
             HaloDBOptions options = new HaloDBOptions();
     
-            // size of each data file will be 1GB.
+            // Size of each data file will be 1GB.
             options.setMaxFileSize(1024 * 1024 * 1024);
-    
-            // the threshold at which page cache is synced to disk.
+
+            // Size of each tombstone file will be 64MB
+            // Large file size mean less file count but will slow down db open time. But if set
+            // file size too small, it will result large amount of tombstone files under db folder
+            options.setMaxTombstoneFileSize(64 * 1024 * 1024);
+
+            // Set the number of threads used to scan index and tombstone files in parallel
+            // to build in-memory index during db open. It must be a positive number which is
+            // not greater than Runtime.getRuntime().availableProcessors().
+            // It is used to speed up db open time.
+            options.setBuildIndexThreads(8);
+
+            // The threshold at which page cache is synced to disk.
             // data will be durable only if it is flushed to disk, therefore
             // more data will be lost if this value is set too high. Setting
             // this value too low might interfere with read and write performance.
@@ -131,6 +142,11 @@ is allocated in native memory, outside the Java heap.
             db.resumeCompaction();
             
             // repeatedly calling pause/resume compaction methods will have no effect.
+
+            // merge tombstone files only when options.isCleanUpTombstonesDuringOpen is true
+            // this is a blocking API, don't run it on a response time/latency sensitive worker thread
+            // better to call it in a periodically scheduled job based on actual situations.
+            db.mergeTombstoneFiles()
     
             // Close the database.
             db.close();
@@ -198,6 +214,12 @@ Delete operation for a key will add a tombstone record to a tombstone file, whic
 This design has the advantage that the tombstone record once written need not be copied again during compaction, but 
 the drawback is that in case of a power loss HaloDB cannot guarantee total ordering when put and delete operations are 
 interleaved (although partial ordering for both is guaranteed).
+
+### DB open time
+Open db could take a few minutes, depends on number of records and tombstones. If the db open time is critical to your
+use case, please keep tombstone file size relatively small and increase the number of threads used in building index.
+See the option setting section in example code above. As best practice, set tombstone file size at 64MB and set build
+index threads to number of available processors divided by number of dbs being opened simultaneously.
 
 ### System requirements. 
 * HaloDB requires Java 8 to run, but has not yet been tested with newer Java versions.  

--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -92,6 +92,14 @@ public final class HaloDB {
         dbInternal.resumeCompaction();
     }
 
+    public void mergeTombstoneFiles() throws HaloDBException{
+        try {
+            dbInternal.mergeTombstoneFiles();
+        } catch (IOException e) {
+            throw new HaloDBException("Error while merging tombstone files", e);
+        }
+    }
+
 
     // methods used in tests.
 

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -330,7 +330,7 @@ class HaloDBInternal {
         int size = entry.getKey().length + TombstoneEntry.TOMBSTONE_ENTRY_HEADER_SIZE;
 
         if ((tombstoneFile == null ||
-            tombstoneFile.getWriteOffset() + size > options.getMaxFileSize()) && !isClosing) {
+            tombstoneFile.getWriteOffset() + size > options.getMaxTombstoneFileSize()) && !isClosing) {
             if (tombstoneFile != null) {
                 tombstoneFile.flushToDisk();
                 tombstoneFile.close();

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -788,6 +788,8 @@ class HaloDBInternal {
             inMemoryIndex.getNoOfSegments(),
             inMemoryIndex.getMaxSizeOfEachSegment(),
             stats.getSegmentStats(),
+            dbDirectory.listDataFiles().length,
+            dbDirectory.listTombstoneFiles().length,
             noOfTombstonesFoundDuringOpen.get(),
             options.isCleanUpTombstonesDuringOpen() ?
                 noOfTombstonesFoundDuringOpen.get() - noOfTombstonesCopiedDuringOpen.get() : 0,

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -462,7 +462,6 @@ class HaloDBInternal {
             }
         } catch (InterruptedException ie) {
             throw new IOException("Building index is interrupted");
-
         } catch (ExecutionException ee) {
             throw new IOException("Error happened during building in-memory index", ee);
         }
@@ -485,7 +484,6 @@ class HaloDBInternal {
             }
         } catch (InterruptedException ie) {
             throw new IOException("Building index is interrupted");
-
         } catch (ExecutionException ee) {
             throw new IOException("Error happened during building in-memory index", ee);
         }

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -451,8 +451,7 @@ class HaloDBInternal {
             indexFileTasks.add(new ProcessIndexFileTask(indexFile, fileId));
         }
 
-        // The number of threads is based on actual test results
-        int nThreads = Integer.max(inMemoryIndex.getNoOfSegments() / 8, 2);
+        int nThreads = options.getBuildIndexThreads();
         logger.info("Building index in parallel with {} threads", nThreads);
 
         ExecutorService executor = Executors.newFixedThreadPool(nThreads);

--- a/src/main/java/com/oath/halodb/HaloDBOptions.java
+++ b/src/main/java/com/oath/halodb/HaloDBOptions.java
@@ -14,6 +14,8 @@ public class HaloDBOptions implements Cloneable {
 
     private int maxFileSize = 1024 * 1024; /* 1mb file recordSize */
 
+    private int maxTombstoneFileSize = 0; /* use maxFileSize by default unless set explicitly */
+
      // Data will be flushed to disk after flushDataSizeBytes have been written.
      // -1 disables explicit flushing and let the kernel handle it.
     private long flushDataSizeBytes = -1;
@@ -51,6 +53,7 @@ public class HaloDBOptions implements Cloneable {
         return MoreObjects.toStringHelper("")
             .add("compactionThresholdPerFile", compactionThresholdPerFile)
             .add("maxFileSize", maxFileSize)
+            .add("maxTombstoneFileSize", getMaxTombstoneFileSize())
             .add("flushDataSizeBytes", flushDataSizeBytes)
             .add("syncWrite", syncWrite)
             .add("numberOfRecords", numberOfRecords)
@@ -72,6 +75,13 @@ public class HaloDBOptions implements Cloneable {
             throw new IllegalArgumentException("maxFileSize should be > 0");
         }
         this.maxFileSize = maxFileSize;
+    }
+
+    public void setMaxTombstoneFileSize(int maxFileSize) {
+        if (maxFileSize <= 0) {
+            throw new IllegalArgumentException("maxFileSize should be > 0");
+        }
+        this.maxTombstoneFileSize = maxFileSize;
     }
 
     public void setFlushDataSizeBytes(long flushDataSizeBytes) {
@@ -96,6 +106,10 @@ public class HaloDBOptions implements Cloneable {
 
     public int getMaxFileSize() {
         return maxFileSize;
+    }
+
+    public int getMaxTombstoneFileSize() {
+        return maxTombstoneFileSize > 0 ? maxTombstoneFileSize : maxFileSize;
     }
 
     public long getFlushDataSizeBytes() {

--- a/src/main/java/com/oath/halodb/HaloDBOptions.java
+++ b/src/main/java/com/oath/halodb/HaloDBOptions.java
@@ -14,7 +14,9 @@ public class HaloDBOptions implements Cloneable {
 
     private int maxFileSize = 1024 * 1024; /* 1mb file recordSize */
 
-    private int maxTombstoneFileSize = 0; /* use maxFileSize by default unless set explicitly */
+    // To keep backward compatibility, initialize to 0 which means
+    // it will fall back to use maxFileSize, see the getter below
+    private int maxTombstoneFileSize = 0;
 
      // Data will be flushed to disk after flushDataSizeBytes have been written.
      // -1 disables explicit flushing and let the kernel handle it.

--- a/src/main/java/com/oath/halodb/HaloDBOptions.java
+++ b/src/main/java/com/oath/halodb/HaloDBOptions.java
@@ -39,6 +39,10 @@ public class HaloDBOptions implements Cloneable {
 
     private int memoryPoolChunkSize = 16 * 1024 * 1024;
 
+    // Number of threads to scan index and tombstone files
+    // to build in-memory index at db open
+    private int buildIndexThreads = 1;
+
     // Just to avoid clients having to deal with CloneNotSupportedException
     public HaloDBOptions clone() {
         try {
@@ -63,6 +67,7 @@ public class HaloDBOptions implements Cloneable {
             .add("useMemoryPool", useMemoryPool)
             .add("fixedKeySize", fixedKeySize)
             .add("memoryPoolChunkSize", memoryPoolChunkSize)
+            .add("buildIndexThreads", buildIndexThreads)
             .toString();
     }
 
@@ -168,6 +173,17 @@ public class HaloDBOptions implements Cloneable {
         this.syncWrite = syncWrites;
     }
 
+    public int getBuildIndexThreads() {
+        return buildIndexThreads;
+    }
+
+    public void setBuildIndexThreads(int buildIndexThreads) {
+        int numOfProcessors = Runtime.getRuntime().availableProcessors();
+        if (buildIndexThreads < 0 || buildIndexThreads > numOfProcessors) {
+            throw new IllegalArgumentException("buildIndexThreads should be > 0 and <= " + numOfProcessors);
+        }
+        this.buildIndexThreads = buildIndexThreads;
+    }
 
     // to be used only in tests.
     private boolean isCompactionDisabled = false;

--- a/src/main/java/com/oath/halodb/HaloDBStats.java
+++ b/src/main/java/com/oath/halodb/HaloDBStats.java
@@ -8,6 +8,7 @@ package com.oath.halodb;
 import com.google.common.base.MoreObjects;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 public class HaloDBStats {
@@ -194,6 +195,34 @@ public class HaloDBStats {
             .add("numberOfSegments", numberOfSegments)
             .add("staleDataPercentPerFile", staleDataMapToString())
             .toString();
+    }
+
+    public Map<String, String> toStringMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("statsResetTime", String.valueOf(statsResetTime));
+        map.put("size", String.valueOf(size));
+        map.put("Options", String.valueOf(options));
+        map.put("isCompactionRunning", String.valueOf(isCompactionRunning));
+        map.put("CompactionJobRateInInterval", String.valueOf(getUnit(compactionRateInInternal)));
+        map.put("CompactionJobRateSinceBeginning", String.valueOf(getUnit(compactionRateSinceBeginning)));
+        map.put("numberOfFilesPendingCompaction", String.valueOf(numberOfFilesPendingCompaction));
+        map.put("numberOfRecordsCopied", String.valueOf(numberOfRecordsCopied));
+        map.put("numberOfRecordsReplaced", String.valueOf(numberOfRecordsReplaced));
+        map.put("numberOfRecordsScanned", String.valueOf(numberOfRecordsScanned));
+        map.put("sizeOfRecordsCopied", String.valueOf(sizeOfRecordsCopied));
+        map.put("sizeOfFilesDeleted", String.valueOf(sizeOfFilesDeleted));
+        map.put("sizeReclaimed", String.valueOf(sizeReclaimed));
+        map.put("rehashCount", String.valueOf(rehashCount));
+        map.put("maxSizePerSegment", String.valueOf(maxSizePerSegment));
+        map.put("numberOfDataFiles", String.valueOf(numberOfDataFiles));
+        map.put("numberOfTombstoneFiles", String.valueOf(numberOfTombstoneFiles));
+        map.put("numberOfTombstonesFoundDuringOpen", String.valueOf(numberOfTombstonesFoundDuringOpen));
+        map.put("numberOfTombstonesCleanedUpDuringOpen", String.valueOf(numberOfTombstonesCleanedUpDuringOpen));
+        map.put("segmentStats", String.valueOf(Arrays.toString(segmentStats)));
+        map.put("numberOfSegments", String.valueOf(numberOfSegments));
+        map.put("staleDataPercentPerFile", String.valueOf(staleDataMapToString()));
+
+        return map;
     }
 
     private String staleDataMapToString() {

--- a/src/main/java/com/oath/halodb/HaloDBStats.java
+++ b/src/main/java/com/oath/halodb/HaloDBStats.java
@@ -27,6 +27,9 @@ public class HaloDBStats {
     private final long numberOfTombstonesFoundDuringOpen;
     private final long numberOfTombstonesCleanedUpDuringOpen;
 
+    private final int numberOfDataFiles;
+    private final int numberOfTombstoneFiles;
+
     private final long numberOfRecordsCopied;
     private final long numberOfRecordsReplaced;
     private final long numberOfRecordsScanned;
@@ -43,10 +46,12 @@ public class HaloDBStats {
 
     public HaloDBStats(long statsResetTime, long size, boolean isCompactionRunning, int numberOfFilesPendingCompaction,
                        Map<Integer, Double> staleDataPercentPerFile, long rehashCount, long numberOfSegments,
-                       long maxSizePerSegment, SegmentStats[] segmentStats, long numberOfTombstonesFoundDuringOpen,
-                       long numberOfTombstonesCleanedUpDuringOpen, long numberOfRecordsCopied,
-                       long numberOfRecordsReplaced, long numberOfRecordsScanned, long sizeOfRecordsCopied,
-                       long sizeOfFilesDeleted, long sizeReclaimed, long compactionRateSinceBeginning, HaloDBOptions options) {
+                       long maxSizePerSegment, SegmentStats[] segmentStats,
+                       int numberOfDataFiles, int numberOfTombstoneFiles,
+                       long numberOfTombstonesFoundDuringOpen, long numberOfTombstonesCleanedUpDuringOpen,
+                       long numberOfRecordsCopied, long numberOfRecordsReplaced, long numberOfRecordsScanned,
+                       long sizeOfRecordsCopied, long sizeOfFilesDeleted, long sizeReclaimed,
+                       long compactionRateSinceBeginning, HaloDBOptions options) {
         this.statsResetTime = statsResetTime;
         this.size = size;
         this.numberOfFilesPendingCompaction = numberOfFilesPendingCompaction;
@@ -55,6 +60,8 @@ public class HaloDBStats {
         this.numberOfSegments = numberOfSegments;
         this.maxSizePerSegment = maxSizePerSegment;
         this.segmentStats = segmentStats;
+        this.numberOfDataFiles = numberOfDataFiles;
+        this.numberOfTombstoneFiles = numberOfTombstoneFiles;
         this.numberOfTombstonesFoundDuringOpen = numberOfTombstonesFoundDuringOpen;
         this.numberOfTombstonesCleanedUpDuringOpen = numberOfTombstonesCleanedUpDuringOpen;
         this.numberOfRecordsCopied = numberOfRecordsCopied;
@@ -129,6 +136,14 @@ public class HaloDBStats {
         return options;
     }
 
+    public int getNumberOfDataFiles() {
+        return numberOfDataFiles;
+    }
+
+    public int getNumberOfTombstoneFiles() {
+        return numberOfTombstoneFiles;
+    }
+
     public long getNumberOfTombstonesFoundDuringOpen() {
         return numberOfTombstonesFoundDuringOpen;
     }
@@ -171,6 +186,8 @@ public class HaloDBStats {
             .add("sizeReclaimed", sizeReclaimed)
             .add("rehashCount", rehashCount)
             .add("maxSizePerSegment", maxSizePerSegment)
+            .add("numberOfDataFiles", numberOfDataFiles)
+            .add("numberOfTombstoneFiles", numberOfTombstoneFiles)
             .add("numberOfTombstonesFoundDuringOpen", numberOfTombstonesFoundDuringOpen)
             .add("numberOfTombstonesCleanedUpDuringOpen", numberOfTombstonesCleanedUpDuringOpen)
             .add("segmentStats", Arrays.toString(segmentStats))

--- a/src/main/java/com/oath/halodb/InMemoryIndex.java
+++ b/src/main/java/com/oath/halodb/InMemoryIndex.java
@@ -48,6 +48,10 @@ class InMemoryIndex {
         return offHeapHashTable.put(key, metaData);
     }
 
+    boolean putIfAbsent(byte[] key, InMemoryIndexMetaData metaData) {
+        return offHeapHashTable.putIfAbsent(key, metaData);
+    }
+
     boolean remove(byte[] key) {
         return offHeapHashTable.remove(key);
     }

--- a/src/main/java/com/oath/halodb/TombstoneEntry.java
+++ b/src/main/java/com/oath/halodb/TombstoneEntry.java
@@ -53,6 +53,10 @@ class TombstoneEntry {
         return checkSum;
     }
 
+    int size() {
+        return TOMBSTONE_ENTRY_HEADER_SIZE + key.length;
+    }
+
     ByteBuffer[] serialize() {
         byte keySize = (byte)key.length;
         ByteBuffer header = ByteBuffer.allocate(TOMBSTONE_ENTRY_HEADER_SIZE);

--- a/src/test/java/com/oath/halodb/HaloDBOptionsTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBOptionsTest.java
@@ -12,5 +12,6 @@ public class HaloDBOptionsTest  extends TestBase {
         HaloDB db = getTestDB(directory, new HaloDBOptions());
         Assert.assertFalse(db.stats().getOptions().isSyncWrite());
         Assert.assertFalse(db.stats().getOptions().isCompactionDisabled());
+        Assert.assertEquals(db.stats().getOptions().getBuildIndexThreads(), 1);
     }
 }

--- a/src/test/java/com/oath/halodb/HaloDBStatsTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBStatsTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class HaloDBStatsTest extends TestBase {
 
@@ -199,4 +200,38 @@ public class HaloDBStatsTest extends TestBase {
         Arrays.fill(expected, s);
         Assert.assertEquals(stats.getSegmentStats(), expected);
     }
+
+    @Test(dataProvider = "Options")
+    public void testStatsToStringMap(HaloDBOptions options) throws HaloDBException {
+        String dir = TestUtils.getTestDirectory("HaloDBStatsTest", "testStatsToStringMap");
+
+        HaloDB db = getTestDB(dir, options);
+
+        HaloDBStats stats = db.stats();
+        Map<String, String> map = stats.toStringMap();
+        Assert.assertEquals(map.size(), 22);
+        Assert.assertNotNull(map.get("statsResetTime"));
+        Assert.assertNotNull(map.get("size"));
+        Assert.assertNotNull(map.get("Options"));
+        Assert.assertNotNull(map.get("isCompactionRunning"));
+        Assert.assertNotNull(map.get("CompactionJobRateInInterval"));
+        Assert.assertNotNull(map.get("CompactionJobRateSinceBeginning"));
+        Assert.assertNotNull(map.get("numberOfFilesPendingCompaction"));
+        Assert.assertNotNull(map.get("numberOfRecordsCopied"));
+        Assert.assertNotNull(map.get("numberOfRecordsReplaced"));
+        Assert.assertNotNull(map.get("numberOfRecordsScanned"));
+        Assert.assertNotNull(map.get("sizeOfRecordsCopied"));
+        Assert.assertNotNull(map.get("sizeOfFilesDeleted"));
+        Assert.assertNotNull(map.get("sizeReclaimed"));
+        Assert.assertNotNull(map.get("rehashCount"));
+        Assert.assertNotNull(map.get("maxSizePerSegment"));
+        Assert.assertNotNull(map.get("numberOfDataFiles"));
+        Assert.assertNotNull(map.get("numberOfTombstoneFiles"));
+        Assert.assertNotNull(map.get("numberOfTombstonesFoundDuringOpen"));
+        Assert.assertNotNull(map.get("numberOfTombstonesCleanedUpDuringOpen"));
+        Assert.assertNotNull(map.get("segmentStats"));
+        Assert.assertNotNull(map.get("numberOfSegments"));
+        Assert.assertNotNull(map.get("staleDataPercentPerFile"));
+    }
+
 }

--- a/src/test/java/com/oath/halodb/TestBase.java
+++ b/src/test/java/com/oath/halodb/TestBase.java
@@ -21,9 +21,11 @@ public class TestBase {
     @DataProvider(name = "Options")
     public Object[][] optionData() {
         HaloDBOptions options = new HaloDBOptions();
+        options.setBuildIndexThreads(2);
         HaloDBOptions withMemoryPool = new HaloDBOptions();
         withMemoryPool.setUseMemoryPool(true);
         withMemoryPool.setMemoryPoolChunkSize(1024 * 1024);
+        withMemoryPool.setBuildIndexThreads(2);
 
         return new Object[][] {
             {options},

--- a/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
+++ b/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
@@ -5,8 +5,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TombstoneFileCleanUpTest extends TestBase {
@@ -234,22 +233,22 @@ public class TombstoneFileCleanUpTest extends TestBase {
         db.close();
         db = getTestDBWithoutDeletingFiles(directory, options);
 
-        // Since keyLength was 19 tombstone entry is 32 bytes.
+        // Since keyLength was 18, plus header length 14, tombstone entry is 32 bytes.
         // Since file size is 512 there would be two tombstone files both of which should be copied.
         File[] tombstoneFiles = FileUtils.listTombstoneFiles(new File(directory));
-        List<TombstoneEntry> tombstones = new ArrayList<>();
+        Set<String> tombstones = new HashSet<>();
         Assert.assertEquals(tombstoneFiles.length, 2);
         for (File f : tombstoneFiles) {
             TombstoneFile tombstoneFile = new TombstoneFile(f, options, dbDirectory);
             tombstoneFile.open();
             TombstoneFile.TombstoneFileIterator iterator = tombstoneFile.newIterator();
             while (iterator.hasNext()) {
-                tombstones.add(iterator.next());
+                tombstones.add(Arrays.toString(iterator.next().getKey()));
             }
         }
 
         for (int i = 0; i < tombstones.size(); i++) {
-            Assert.assertEquals(tombstones.get(i).getKey(), records.get(i).getKey());
+            Assert.assertTrue(tombstones.contains(Arrays.toString(records.get(i).getKey())));
         }
 
         HaloDBStats stats = db.stats();

--- a/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
+++ b/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
@@ -10,11 +10,10 @@ import java.util.stream.Collectors;
 
 public class TombstoneFileCleanUpTest extends TestBase {
 
-    @Test
-    public void testDeleteAllRecords() throws HaloDBException, IOException {
+    @Test(dataProvider = "Options")
+    public void testDeleteAllRecords(HaloDBOptions options) throws HaloDBException, IOException {
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testDeleteAllRecords");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setCleanUpTombstonesDuringOpen(true);
         options.setCompactionThresholdPerFile(1);
         options.setMaxFileSize(1024 * 1024);
@@ -61,11 +60,10 @@ public class TombstoneFileCleanUpTest extends TestBase {
         Assert.assertEquals(noOfRecords - noOfRecordsPerFile, stats.getNumberOfTombstonesCleanedUpDuringOpen());
     }
 
-    @Test
-    public void testDeleteAndInsertRecords() throws IOException, HaloDBException {
+    @Test(dataProvider = "Options")
+    public void testDeleteAndInsertRecords(HaloDBOptions options) throws IOException, HaloDBException {
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testDeleteAndInsertRecords");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setCleanUpTombstonesDuringOpen(true);
         options.setCompactionThresholdPerFile(1);
         HaloDB db = getTestDB(directory, new HaloDBOptions());
@@ -97,11 +95,10 @@ public class TombstoneFileCleanUpTest extends TestBase {
         Assert.assertEquals(noOfRecords, stats.getNumberOfTombstonesCleanedUpDuringOpen());
     }
 
-    @Test
-    public void testDeleteRecordsWithoutCompaction() throws IOException, HaloDBException {
+    @Test(dataProvider = "Options")
+    public void testDeleteRecordsWithoutCompaction(HaloDBOptions options) throws IOException, HaloDBException {
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testDeleteRecordsWithoutCompaction");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setMaxFileSize(1024 * 1024);
         options.setCompactionThresholdPerFile(1);
         options.setCleanUpTombstonesDuringOpen(true);
@@ -156,11 +153,10 @@ public class TombstoneFileCleanUpTest extends TestBase {
         Assert.assertEquals(0, stats.getNumberOfTombstonesCleanedUpDuringOpen());
     }
 
-    @Test
-    public void testWithCleanUpTurnedOff() throws IOException, HaloDBException {
+    @Test(dataProvider = "Options")
+    public void testWithCleanUpTurnedOff(HaloDBOptions options) throws IOException, HaloDBException {
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testWithCleanUpTurnedOff");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setCleanUpTombstonesDuringOpen(false);
         options.setCompactionThresholdPerFile(1);
         options.setMaxFileSize(1024 * 1024);
@@ -198,13 +194,12 @@ public class TombstoneFileCleanUpTest extends TestBase {
         Assert.assertEquals(0, stats.getNumberOfTombstonesCleanedUpDuringOpen());
     }
 
-    @Test
-    public void testCopyMultipleTombstoneFiles() throws HaloDBException, IOException {
+    @Test(dataProvider = "Options")
+    public void testCopyMultipleTombstoneFiles(HaloDBOptions options) throws HaloDBException, IOException {
         //Test to make sure that rollover to tombstone files work correctly during cleanup. 
 
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testCopyMultipleTombstoneFiles");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setCleanUpTombstonesDuringOpen(true);
         options.setCompactionDisabled(true);
         options.setMaxFileSize(512);
@@ -256,11 +251,10 @@ public class TombstoneFileCleanUpTest extends TestBase {
         Assert.assertEquals(0, stats.getNumberOfTombstonesCleanedUpDuringOpen());
     }
 
-    @Test
-    public void testMergeTombstoneFiles() throws IOException, HaloDBException {
+    @Test(dataProvider = "Options")
+    public void testMergeTombstoneFiles(HaloDBOptions options) throws IOException, HaloDBException {
         String directory = TestUtils.getTestDirectory("TombstoneFileCleanUpTest", "testMergeTombstoneFiles");
 
-        HaloDBOptions options = new HaloDBOptions();
         options.setCompactionThresholdPerFile(0.4);
         options.setMaxFileSize(16 * 1024);
         options.setMaxTombstoneFileSize(2 * 1024);


### PR DESCRIPTION
In our production server, open a db with around 300 millions records take over 5 mins (see logs below). When there are multiple db instances to open during service start up, it takes too long time.

This change is to scan index files to build in-memory index in parallel with ExecutorService. Use ```putIfAbsent``` (new added) and ```replace``` to ensure only latest entry is put to index table.

@amannaly Please help review

About test: It seems that the existing DataConsistencyTest already have this change covered. I will do data consistency validation offline with real production data and will update with the results.

```
=2019-05-02 23:40:46,455  INFO [pool-5-thread-2] (com.oath.halodb.HaloDBInternal) - Completed scanning all key files in 374
=2019-05-02 23:41:23,401  INFO [pool-5-thread-3] (com.oath.halodb.HaloDBInternal) - Completed scanning all key files in 411
=2019-05-02 23:51:03,895  INFO [pool-5-thread-7] (com.oath.halodb.HaloDBInternal) - Completed scanning all key files in 482
=2019-05-17 04:39:21,164  INFO [pool-5-thread-16] (com.oath.halodb.HaloDBInternal) - Completed scanning all key files in 414
```