### PR TITLE
Merge tombstone files right after memory index is built

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,6 @@ is allocated in native memory, outside the Java heap.
             
             // repeatedly calling pause/resume compaction methods will have no effect.
 
-            // merge tombstone files only when options.isCleanUpTombstonesDuringOpen is true
-            // this is a blocking API, don't run it on a response time/latency sensitive worker thread
-            // better to call it in a periodically scheduled job based on actual situations.
-            db.mergeTombstoneFiles()
-    
             // Close the database.
             db.close();
 ```

--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -92,19 +92,15 @@ public final class HaloDB {
         dbInternal.resumeCompaction();
     }
 
-    public void mergeTombstoneFiles() throws HaloDBException{
-        try {
-            dbInternal.mergeTombstoneFiles();
-        } catch (IOException e) {
-            throw new HaloDBException("Error while merging tombstone files", e);
-        }
-    }
-
-
     // methods used in tests.
 
     @VisibleForTesting
     boolean isCompactionComplete() {
         return dbInternal.isCompactionComplete();
+    }
+
+    @VisibleForTesting
+    boolean isTombstoneFilesMerging() {
+        return dbInternal.isTombstoneFilesMerging();
     }
 }

--- a/src/test/java/com/oath/halodb/TestBase.java
+++ b/src/test/java/com/oath/halodb/TestBase.java
@@ -54,6 +54,7 @@ public class TestBase {
         this.directory = directory;
         File dir = new File(directory);
         db = HaloDB.open(dir, options);
+        TestUtils.waitForTombstoneFileMergeComplete(db);
         return db;
     }
 

--- a/src/test/java/com/oath/halodb/TestUtils.java
+++ b/src/test/java/com/oath/halodb/TestUtils.java
@@ -220,6 +220,17 @@ public class TestUtils {
         }
     }
 
+    static void waitForTombstoneFileMergeComplete(HaloDB db) {
+        while (db.isTombstoneFilesMerging()) {
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException e) {
+                logger.error("Thread interrupted while waiting for tombstone file merge to complete");
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     static Optional<File> getLatestDataFile(String directory) {
         return Arrays.stream(FileUtils.listDataFiles(new File(directory)))
             .filter(f -> HaloDBFile.findFileType(f) == HaloDBFile.FileType.DATA_FILE)

--- a/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
+++ b/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
@@ -314,37 +314,18 @@ public class TombstoneFileCleanUpTest extends TestBase {
         options.setCleanUpTombstonesDuringOpen(true);
         db = getTestDBWithoutDeletingFiles(directory, options);
 
-        // all original tombstone files are rolled over to new ones with inactive entries dropped
-        // total tombstone file count are same because not merge during db open
-        // listTombstoneFiles return a sorted file list
-        current = FileUtils.listTombstoneFiles(new File(directory));
-        Assert.assertEquals(current.length, original.length);
-        Assert.assertTrue(getFileId(current[0].getName()) > getFileId(original[original.length-1].getName()));
-
-        // Merge tombstone files and verify file number reduced
-        db.mergeTombstoneFiles();
-
         original = current;
         current = FileUtils.listTombstoneFiles(new File(directory));
         // See comments above how 4 is calculated
         Assert.assertEquals(current.length, 4);
+        // All tombstone files are rolled over to new files
         Assert.assertTrue(getFileId(current[0].getName()) > getFileId(original[original.length-1].getName()));
 
-        // Test mergeTombstoneFiles with currentTombstoneFile present
-        // Delete 1 record to initialize currentTombstoneFile
+        // Delete 1 record and verify currentTombstoneFile is initialized
         db.delete(records.get(1).getKey());
         original = current;
         current = FileUtils.listTombstoneFiles(new File(directory));
         Assert.assertEquals(current.length, original.length + 1);
-
-        // Merge tombstone files again, verify tombstones roll over to new files, file count keep same
-        db.mergeTombstoneFiles();
-        original = current;
-        current = FileUtils.listTombstoneFiles(new File(directory));
-        Assert.assertEquals(current.length, original.length);
-        // Verify currentTombstoneFile is not rolled over
-        Assert.assertEquals(current[0].getName(), original[original.length-1].getName());
-
         db.close();
     }
 


### PR DESCRIPTION
@bellofreedom @amannaly @finaldie

**Issue #, if available:**
As a DB specific cleanup job,  ```mergeTombstoneFiles``` is only valuable at db open when ```isCleanUpTombstonesDuringOpen``` is ```true```. So instead of exposing it to client, it makes more sense to keep it as internal procedure and do it with a background thread right after in-memory index is built in db open.

**Description of changes:**

- Remove the public API ```mergeTombstoneFiles```
- Do tombstone file merge during db open

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
