### PR TITLE
Fix build error by using trusty as build dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6