### PR TITLE
Make pauseCompaction act as sync call by waiting for compaction thread stopped

### DIFF
--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -312,6 +312,14 @@ class HaloDBInternal {
 
     void pauseCompaction() throws IOException {
         compactionManager.pauseCompactionThread();
+        // Wait for compaction thread exit
+        while (compactionManager.isCompactionRunning()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                logger.error("pauseCompaction is interrupted while waiting for compaction thread exit");
+            }
+        }
     }
 
     void resumeCompaction() {


### PR DESCRIPTION
@bellofreedom 

This change is to make ```pauseCompaction``` blocking until compaction thread exit. Please help review.

It is supposed the thread will exit after finish compaction to current file, so didn't add a timeout. 
