### PR TITLE
Add jacoco test coverage build profile. (#46)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <argLine></argLine>
     </properties>
 
 
@@ -118,7 +119,7 @@
                             <value>com.oath.halodb.TestListener</value>
                         </property>
                     </properties>
-                    <argLine>-Xms2G -Xmx2G</argLine>
+                    <argLine>@{argLine} -Xms1G -Xmx2G</argLine>
                 </configuration>
             </plugin>
 
@@ -142,6 +143,35 @@
         </resources>
 
     </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.5</version>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
  To generate a coverage report, run 'mvn install -Pcoverage'.
  To generate one for only a subset of tests, run
  'mvn install -Pcoverage -Dtest=TestNamePattern'


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
