### PR TITLE
Add Manual Compaction to HaloDB (#45)

### DIFF
--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -5,11 +5,10 @@
 
 package com.oath.halodb;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public final class HaloDB {
 
@@ -80,12 +79,25 @@ public final class HaloDB {
         return new HaloDBIterator(dbInternal);
     }
 
-    public void pauseCompaction() throws HaloDBException {
+    /**
+     * Force a compaction on all data files that have more stale data than the provided threshold ratio.
+     * A compactionThreshold of 0 would force all files that have any stale data to compact,
+     * 0.1 would force those that have more than 10% space stale to compact.
+     **/
+    public void forceCompaction(float compactionThreshold) {
+        dbInternal.forceCompaction(compactionThreshold);
+    }
+
+    public void pauseCompaction(boolean awaitPending) throws HaloDBException {
         try {
-            dbInternal.pauseCompaction();
+            dbInternal.pauseCompaction(awaitPending);
         } catch (IOException e) {
             throw new HaloDBException("Error while trying to pause compaction thread", e);
         }
+    }
+
+    public void pauseCompaction() throws HaloDBException {
+        pauseCompaction(false);
     }
 
     public boolean snapshot() {
@@ -105,12 +117,6 @@ public final class HaloDB {
     }
 
     // methods used in tests.
-
-    @VisibleForTesting
-    boolean isCompactionComplete() {
-        return dbInternal.isCompactionComplete();
-    }
-
     @VisibleForTesting
     boolean isTombstoneFilesMerging() {
         return dbInternal.isTombstoneFilesMerging();

--- a/src/test/java/com/oath/halodb/TestUtils.java
+++ b/src/test/java/com/oath/halodb/TestUtils.java
@@ -5,9 +5,6 @@
 
 package com.oath.halodb;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,6 +24,9 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestUtils {
     private static final Logger logger = LoggerFactory.getLogger(TestUtils.class);
@@ -212,22 +212,16 @@ public class TestUtils {
 
     /**
      * This method will work correctly only after all the writes to the db have been completed.
+     * @throws HaloDBException
      */
-    static void waitForCompactionToComplete(HaloDB db) {
-        while (!db.isCompactionComplete()) {
-            try {
-                Thread.sleep(1_000);
-            } catch (InterruptedException e) {
-                logger.error("Thread interrupted while waiting for compaction to complete");
-                throw new RuntimeException(e);
-            }
-        }
+    static void waitForCompactionToComplete(HaloDB db) throws HaloDBException {
+        db.pauseCompaction(true);
     }
 
     static void waitForTombstoneFileMergeComplete(HaloDB db) {
         while (db.isTombstoneFilesMerging()) {
             try {
-                Thread.sleep(1_000);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
                 logger.error("Thread interrupted while waiting for tombstone file merge to complete");
                 throw new RuntimeException(e);


### PR DESCRIPTION
  Add the 'forceCompaction' method to HaloDB,
  which takes a compactionThreshold value and
  will trigger compaction on all files that have
  stale data above the threshold.

  Additionally clean up how pauseCompaction()
  works so that it awaits pending compactions.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
