### PR TITLE
Ensure executor service is shutdown.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <scm>

--- a/src/main/java/com/oath/halodb/HaloDBOptions.java
+++ b/src/main/java/com/oath/halodb/HaloDBOptions.java
@@ -181,7 +181,7 @@ public class HaloDBOptions implements Cloneable {
 
     public void setBuildIndexThreads(int buildIndexThreads) {
         int numOfProcessors = Runtime.getRuntime().availableProcessors();
-        if (buildIndexThreads < 0 || buildIndexThreads > numOfProcessors) {
+        if (buildIndexThreads <= 0 || buildIndexThreads > numOfProcessors) {
             throw new IllegalArgumentException("buildIndexThreads should be > 0 and <= " + numOfProcessors);
         }
         this.buildIndexThreads = buildIndexThreads;

--- a/src/test/java/com/oath/halodb/HaloDBOptionsTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBOptionsTest.java
@@ -3,6 +3,8 @@ package com.oath.halodb;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
 public class HaloDBOptionsTest  extends TestBase {
 
     @Test
@@ -13,5 +15,23 @@ public class HaloDBOptionsTest  extends TestBase {
         Assert.assertFalse(db.stats().getOptions().isSyncWrite());
         Assert.assertFalse(db.stats().getOptions().isCompactionDisabled());
         Assert.assertEquals(db.stats().getOptions().getBuildIndexThreads(), 1);
+    }
+
+    @Test
+    public void testSetBuildIndexThreads() {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        HaloDBOptions options = new HaloDBOptions();
+
+        // Test valid boundaries.
+        if (availableProcessors > 1) {
+            options.setBuildIndexThreads(availableProcessors);
+            Assert.assertEquals(options.getBuildIndexThreads(), availableProcessors);
+        }
+        options.setBuildIndexThreads(1);
+        Assert.assertEquals(options.getBuildIndexThreads(), 1);
+
+        // Test invalid boundaries.
+        assertThatIllegalArgumentException().isThrownBy(() -> options.setBuildIndexThreads(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> options.setBuildIndexThreads(availableProcessors + 1));
     }
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

While looking at the code, I noticed that the ExecutorService used by buildInMemoryIndex() will not shutdown if an exception occurs. This PR fixes that.

I also noticed that buildInMemoryIndex() was unnecessarily passing the options member field (and, in fact, was the only such instance method to pass a member field). So, I removed the unnecessary parameter.

Finally, I noticed that HaloDBOptions.setBuildIndexThreads() allowed you to specify 0... which, if specified, would result in an exception in buildInMemoryIndex(). So, I fixed that and added tests.
