### PR TITLE
Fix recovery issue on windows.

### DIFF
--- a/src/main/java/com/oath/halodb/HaloDBFile.java
+++ b/src/main/java/com/oath/halodb/HaloDBFile.java
@@ -176,11 +176,13 @@ class HaloDBFile {
         logger.info("Recovered {} records from file {} with size {}. Size after repair {}.", count, getName(), getSize(), repairFile.getSize());
         repairFile.flushToDisk();
         repairFile.indexFile.flushToDisk();
+        indexFile.close();
+        repairFile.indexFile.close();
         Files.move(repairFile.indexFile.getPath(), indexFile.getPath(), REPLACE_EXISTING, ATOMIC_MOVE);
-        Files.move(repairFile.getPath(), getPath(), REPLACE_EXISTING, ATOMIC_MOVE);
-        dbDirectory.syncMetaData();
         repairFile.close();
         close();
+        Files.move(repairFile.getPath(), getPath(), REPLACE_EXISTING, ATOMIC_MOVE);
+        dbDirectory.syncMetaData();
         return openForReading(dbDirectory, getPath().toFile(), fileType, options);
     }
 


### PR DESCRIPTION
Fixes #23. On Windows, if any file specified in the call to `Files.move` is open by any process (including our own), the call will throw a FileSystemException.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
